### PR TITLE
Silence the mv error if file is missing

### DIFF
--- a/testdroid_cmdline.sh
+++ b/testdroid_cmdline.sh
@@ -500,7 +500,7 @@ which bc
 if [ $? -ne 0 ]; then echo "Please install 'bc' before running script." ; usage ; exit 104; fi
 
 # Create test.zip
-mv ${TEST_ZIP_FILE} test_previous.zip
+mv ${TEST_ZIP_FILE} test_previous.zip 2>/dev/null
 zip_temp_dir="testzip"
 rm -rf "${zip_temp_dir:?}"
 cp -rf "${TEST_ARCHIVE_FOLDER:?}" "${zip_temp_dir:?}"


### PR DESCRIPTION
We really never care if it fails and the output is confusing.
