### PR TITLE
Added support to lock the instance of configuring project

### DIFF
--- a/testdroid_cmdline.sh
+++ b/testdroid_cmdline.sh
@@ -457,6 +457,8 @@ function get_project_configuration_lock {
     current_value=$(echo "$response" | jq -r '.withAnnotation')
     # set lock if there is no lock in place
     if [ -z "$current_value" ]; then
+      # Refresh the lock to avoid premature timeout
+      mylock="$(generate_project_configuration_lock)"
       response=$(auth_curl -POST -F withAnnotation="$mylock" "${project_config_url}")
     else
       project_instance=$(echo $response |jq -r '.withAnnotation' |jq -r '.instance')


### PR DESCRIPTION
This allows launching several tests concurrently for same project. Without the locking the concurrent configurations would clash and we might not start test with correct params/test.zip/test app.

The lock is done in a field called 'withAnnotation' for project. I do not know what the actual purpose  of this field is so I use it to store the lock-information.
