### PR TITLE
Removed autostart of appium for both Android and iOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ addons:
       - curl
 env:
   global: >
-    - TD_BUILD="unity-ads/android/example/build/outputs/apk/example-debug.apk"
+    - EXAMPLE_APP_URL="https://raw.githubusercontent.com/UnityTech/GamesTestAutomationExample/master/example-unity-project/example-app.apk"
+    - TD_BUILD="example-app.apk"
     - TD_RUN_NAME="Travis iTests-test No.${TRAVIS_BUILD_NUMBER} $TRAVIS_BRANCH"
     - TD_BASE_CMD_API_KEY='./testdroid_cmdline.sh -u $TD_API_TOKEN -t "$TD_PROJECT" -a "$TD_BUILD" -r "$TD_RUN_NAME" -z fake_test_dir'
     - CMD_TD_LIST_API_KEY="$TD_BASE_CMD_API_KEY -l"
     - CMD_TD_SIMULATE="$TD_BASE_CMD -d $TD_DEVICE_GROUP_ID -s"
     - CMD_TD_SIMULATE_API_KEY="$TD_BASE_CMD_API_KEY -d $TD_DEVICE_GROUP_ID -s"
 install:
-  - git clone https://github.com/Applifier/unity-ads unity-ads
-  - (cd unity-ads/android/example ; gradle build)
+  - curl "$EXAMPLE_APP_URL" -o "$TD_BUILD"
   - mkdir fake_test_dir
 script:
   - eval $CMD_TD_LIST_API_KEY

--- a/run-tests-android.sh
+++ b/run-tests-android.sh
@@ -6,37 +6,17 @@ export TESTDROID=1
 TEST=${TEST:="your_test.js"} #Name of the test file
 
 ##### Cloud testrun dependencies start
-echo "Extracting tests.zip..."
+echo "[Testdroid-ssa-client] Extracting tests.zip..."
 unzip tests.zip
 
-echo "Starting Appium ..."
-appium-1.5 --log-no-colors --log-timestamp >appium.log 2>&1 &
-
-echo -n "Waiting for Appium server to be ready "
-start_string="Appium REST http interface listener started"
-retry=30
-while [ $retry -gt 0 ]
-do
-  sleep 1
-  echo -n "."
-  if [ -n "$(grep -s "$start_string" appium.log)" ]; then
-    retry=0
-    echo " done"
-    echo $(grep "$start_string" appium.log)
-  else
-    ((retry--))
-    if [ $retry -eq 0 ]; then
-      echo " waited 30 seconds but server was not ready"
-    fi
-  fi
-done
+echo "[Testdroid-ssa-client] NOT Starting Appium, start it in your test script if needed!"
 
 ##### Cloud testrun dependencies end.
 
 export APPIUM_APPFILE=$PWD/application.apk #App file is at current working folder
 
 ## Run the test:
-echo "Running test ${TEST}"
+echo "[Testdroid-ssa-client] Running test ${TEST}"
 rm -rf screenshots
 mkdir screenshots
 

--- a/run-tests-ios.sh
+++ b/run-tests-ios.sh
@@ -6,31 +6,11 @@ export TESTDROID=1
 TEST=${TEST:="your_test.js"} #Name of the test file
 
 ##### Cloud testrun dependencies start
-echo "Extracting tests.zip..."
+echo "[Testdroid-ssa-client] Extracting tests.zip..."
 
 unzip tests.zip
 
-echo "Starting Appium ..."
-/opt/appium/bin/appium.js -U ${UDID} --command-timeout 120 --log-no-colors --log-timestamp >appium.log 2>&1 &
-
-echo -n "Waiting for Appium server to be ready "
-start_string="Appium REST http interface listener started"
-retry=30
-while [ $retry -gt 0 ]
-do
-  sleep 1
-  echo -n "."
-  if [ -n "$(grep -s "$start_string" appium.log)" ]; then
-    retry=0
-    echo " done"
-    echo $(grep "$start_string" appium.log)
-  else
-    ((retry--))
-    if [ $retry -eq 0 ]; then
-      echo " waited 30 seconds but server was not ready"
-    fi
-  fi
-done
+echo "[Testdroid-ssa-client] NOT Starting Appium, start it in your test script if needed!"
 
 export APPIUM_APPFILE=$PWD/application.ipa #App file is at current working folder
 


### PR DESCRIPTION
If your scripts require appium then please start it yourself. 

There's now several versions of appium and not all tests use appium at all. It does not make much sense to auto start it each time since in most tests we kill the process and start a new one.