### PR TITLE
Feature/auto retry count param

### DIFF
--- a/testdroid_cmdline.sh
+++ b/testdroid_cmdline.sh
@@ -277,7 +277,7 @@ function setup_project_settings {
     flags_to_alter="${flags_to_alter} -F usedDeviceGroupId=${device_group_id}"
   fi
 
-  if [ ! -z "$AUTO_RETRY_COUNT" ]; then
+  if [ -n "$AUTO_RETRY_COUNT" ]; then
     flags_to_alter="${flags_to_alter} -F maxAutoRetriesCount=${AUTO_RETRY_COUNT}"
   fi
 
@@ -306,11 +306,13 @@ function setup_project_settings {
     prettyp "Unable to set timeout '${PROJECT_TIMEOUT}' for project! Exiting. Response was '$response'"
     exit 11
   fi
-  if [ "$used_auto_retry_count" == "$AUTO_RETRY_COUNT" ]; then
-    prettyp "Using auto retry count '$used_auto_retry_count'"
-  else
-    prettyp "Unable to set auto retry count '${AUTO_RETRY_COUNT}' for project! Exiting. Response was '$response'"
-    exit 11
+  if [ -n "$AUTO_RETRY_COUNT" ]; then
+    if [ "$used_auto_retry_count" == "$AUTO_RETRY_COUNT" ]; then
+      prettyp "Using auto retry count '$used_auto_retry_count'"
+    else
+      prettyp "Unable to set auto retry count '${AUTO_RETRY_COUNT}' for project! Exiting. Response was '$response'"
+      exit 11
+    fi
   fi
 }
 

--- a/testdroid_cmdline.sh
+++ b/testdroid_cmdline.sh
@@ -70,7 +70,7 @@ function usage(){
   echo -e "\t -f\tSkip video files when downloading test results"
   echo -e "\t -i\tSet timeout value for project in seconds. Will use 600s (10min) unless specified"
   echo -e "\t -x\tSet timeout value for testdroid client run. There's no timeout by default."
-  echo -e "\t -q\tSet counter for auto retrying failed tests. Default counter value is 3."
+  echo -e "\t -q\tSet counter for auto retrying failed devices. Default counter value is 3."
   echo -e "Project timeout vs. testdroid client timeout:"
   echo -e "\t Project timeout applies to a single device run, whereas testdroid client timeout sets"
   echo -e "\t maximum duration for the testdroid-client run. When the client timeout is reached,"

--- a/testdroid_cmdline.sh
+++ b/testdroid_cmdline.sh
@@ -703,10 +703,10 @@ if [ -n "${RESULTS_RUN_ID}" ]; then
   exit
 fi
 
-if [[ ! $TESTDROID_SSA_CLIENT_TIMEOUT =~ ^[0-9]+$ ]]; then
+if [[ ! "$TESTDROID_SSA_CLIENT_TIMEOUT" =~ ^[0-9]+$ ]]; then
     echo 'Testdroid client timeout must be an integer!' ; exit 1 ; fi
 
-if [[ ! $AUTO_RETRY_COUNT =~ ^[0-9]+$ ]]; then
+if [[ ! -z "$AUTO_RETRY_COUNT" && ! "$AUTO_RETRY_COUNT" =~ ^[0-9]+$ ]]; then
     echo 'Auto retry count must be an integer!' ; exit 1 ; fi
 
 if [ -z "${APP_PATH}" ]; then echo "Please specify app path!" ; usage ; exit 1 ; fi


### PR DESCRIPTION
This PR adds an optional flag to set count for auto retrying tests on devices that failed. By default, 3 retries are performed.